### PR TITLE
Анимируем фон при переключении экранов

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -493,6 +493,7 @@
         </div>
       </div>
     </section>
+    <div class="screen__overlay" id="screen__overlay"></div>
 
   </main>
 

--- a/source/scss/blocks/screen.scss
+++ b/source/scss/blocks/screen.scss
@@ -368,7 +368,7 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 1;
+  z-index: $screen-overlay-z-index;
   background-color: $c-dark;
   transition: none;
   transform: translateY(100%);

--- a/source/scss/blocks/screen.scss
+++ b/source/scss/blocks/screen.scss
@@ -361,3 +361,20 @@
 .screen--rules {
   background-color: $c-dark;
 }
+
+.screen__overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  background-color: $c-dark;
+  transition: none;
+  transform: translateY(100%);
+
+  &--active {
+    transition: transform 0.25s cubic-bezier(0, 0.65, 0, 0.56);
+    transform: translateY(0);
+  }
+}

--- a/source/scss/general/variables/components/z-index.scss
+++ b/source/scss/general/variables/components/z-index.scss
@@ -1,0 +1,1 @@
+$screen-overlay-z-index: 1;

--- a/source/scss/general/variables/variables.scss
+++ b/source/scss/general/variables/variables.scss
@@ -1,3 +1,4 @@
 @import "components/colors";
 @import "components/fonts";
 @import "components/media";
+@import "components/z-index";


### PR DESCRIPTION
Не знаю, как такую задачу можно было решить стилями. На мой взгляд, так была бы нарушена логика и ничего, кроме костылей, в голову не приходит.

Пришлось капитально перепилить всю логику переключения между экранами и скролла. Прошу не рубить решение сразу, а обсудить, так как на мой взгляд, это единственно правильный подход.

Также, теперь в конструкторе класса FullPageScroll можно задать конфиг, с каких страниц и на какие должен появляться оверлей. Мне кажется, это очень удобно

---
:mortar_board: [Анимируем фон при переключении экранов](https://up.htmlacademy.ru/animation/1/user/337099/tasks/4)

:boom: https://htmlacademy-animation.github.io/337099-magic-vacation-1/3/